### PR TITLE
Allow Angular 16+ usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **ai-sdk-ng** is an Angular library that provides seamless integration with [Vercel AI SDK v5 (beta)](https://vercel.com/blog/vercel-ai-sdk-v5) for building AI-powered apps in Angular. It offers chat, text completion, and structured output capabilities with reactive state management and type-safe schema validation.
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.x.
+This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.x. The library supports Angular 16 or higher.
 
 ---
 

--- a/projects/ai-sdk-ng/README.md
+++ b/projects/ai-sdk-ng/README.md
@@ -1,6 +1,6 @@
 # AiSdkNg
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.0.0.
+This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.0.0. The library supports Angular 16 or higher.
 
 ## Code scaffolding
 

--- a/projects/ai-sdk-ng/package.json
+++ b/projects/ai-sdk-ng/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/core": "^20.0.0"
+    "@angular/common": ">=16.0.0",
+    "@angular/core": ">=16.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
## Summary
- relax Angular peer dependency versions to allow Angular 16 or higher
- note Angular 16+ compatibility in README files

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d2e96b3ac83288d441a5c14926186