### PR TITLE
Fix Chat spec import

### DIFF
--- a/projects/ai-sdk-ng/src/lib/chat.ng.spec.ts
+++ b/projects/ai-sdk-ng/src/lib/chat.ng.spec.ts
@@ -9,7 +9,7 @@ import {
   TextStreamChatTransport,
   type UIMessageStreamPart,
 } from "ai";
-import { Chat } from "./chat.ng.js";
+import { Chat } from "./chat.ng";
 
 function formatStreamPart(part: UIMessageStreamPart) {
   return `data: ${JSON.stringify(part)}\n\n`;


### PR DESCRIPTION
## Summary
- correct the Chat import path for specs

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686d32cef13083288fad08303aebd72d