### PR TITLE
Update ai SDK to beta.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "ai-sdk-ng",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@angular/common": "^20.0.0",
         "@angular/compiler": "^20.0.0",
         "@angular/core": "^20.0.0",
-        "ai": "^5.0.0-beta.3",
+        "ai": "5.0.0-beta.9",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -28,9 +29,9 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.0-beta.3.tgz",
-      "integrity": "sha512-g49gMSkXy94lYvl5LRh438OR/0JCG6ol0jV+iLot7cy5HLltZlGocEuauETBu4b10mDXOd7XIjTEZoQpYFMYLQ==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.0-beta.4.tgz",
+      "integrity": "sha512-P5/dS7pb+cBRWnTP0Aezq3/3PIrF+p64fUTxBAyZIert8qTyHm2gd6atbAJZprZ304Ui3QjA9MFybAa849//2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0-beta.1",
@@ -3627,12 +3628,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.0-beta.4.tgz",
-      "integrity": "sha512-AHEW+72mOrJaCN/7D/mbRKfwUpdMpzYKPLhkPZzyeQQXDDWaojo7x3bmtZZ5JhaKH/10oVTBP/KVL3Mqt4vsFQ==",
+      "version": "5.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.0-beta.9.tgz",
+      "integrity": "sha512-PjOODpw8QKIl9UabG1yzZ8WplDQUt8liwTz/WZMhKB+AvXR9+xp7W0e7DbG2o5lPjBRLaN8Xh2w4XtFhb/DStw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "1.0.0-beta.3",
+        "@ai-sdk/gateway": "1.0.0-beta.4",
         "@ai-sdk/provider": "2.0.0-beta.1",
         "@ai-sdk/provider-utils": "3.0.0-beta.2",
         "@opentelemetry/api": "1.9.0"
@@ -8505,9 +8506,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/common": "^20.0.0",
     "@angular/compiler": "^20.0.0",
     "@angular/core": "^20.0.0",
-    "ai": "^5.0.0-beta.3",
+    "ai": "5.0.0-beta.9",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },


### PR DESCRIPTION
## Summary
- use ai SDK version 5.0.0-beta.9

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d355b12788328bce5bf495464bf57