### PR TITLE
Update Angular dependencies handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@angular/common": "^20.0.0",
-        "@angular/compiler": "^20.0.0",
-        "@angular/core": "^20.0.0",
         "ai": "5.0.0-beta.9",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
@@ -26,6 +23,11 @@
         "ng-packagr": "^20.0.0",
         "typescript": "~5.8.2",
         "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0",
+        "@angular/compiler": "^20.0.0",
+        "@angular/core": "^20.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -402,6 +404,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.0.5.tgz",
       "integrity": "sha512-R7SQaOVYjVnrGHOq2RnuPn0pGofGVTDgy5EoHzF8ulb5MG/d7GFwCaMgfAbp3/Cw1CJzP2ZB54O8x9SMuqExyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -418,6 +421,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.0.5.tgz",
       "integrity": "sha512-eHHnh+wIUC+8mfmlPnkzVfonQCA3LAbPWgYpvEQtBh0/R3cZBN6tmOxWQB8IuLu+cZ0eXS/a14mqHJp3c3u7Hg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -524,6 +528,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.0.5.tgz",
       "integrity": "sha512-r7YQXZvKPAMUXeo3psKTZxyYJrwidTwDPrzxMX3EGqZxv0eDnMPWCxH2y0O2X4BT0Nm1iAqx3zhGrSFc0vD60Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/compiler": "^20.0.0",
-    "@angular/core": "^20.0.0",
     "ai": "5.0.0-beta.9",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
@@ -37,5 +34,10 @@
     "ng-packagr": "^20.0.0",
     "typescript": "~5.8.2",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "@angular/common": "^20.0.0",
+    "@angular/compiler": "^20.0.0",
+    "@angular/core": "^20.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- move Angular packages to peerDependencies
- update package-lock.json
- keep tests/build passing

## Testing
- `npm run build --silent`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686d410b19188328b02ebb1aa278d2a9