### PR TITLE
Support Angular >=16

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **ai-sdk-ng** is an Angular library that provides seamless integration with [Vercel AI SDK v5 (beta)](https://vercel.com/blog/vercel-ai-sdk-v5) for building AI-powered apps in Angular. It offers chat, text completion, and structured output capabilities with reactive state management and type-safe schema validation.
 
-This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 20.x. The library supports Angular 16 or higher.
+This project was generated using the [Angular CLI](https://github.com/angular/angular-cli) and supports Angular **16 or higher**.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-ng",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-ng",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ai": "5.0.0-beta.9",
@@ -25,9 +25,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@angular/common": "^20.0.0",
-        "@angular/compiler": "^20.0.0",
-        "@angular/core": "^20.0.0"
+        "@angular/common": ">=16.0.0",
+        "@angular/compiler": ">=16.0.0",
+        "@angular/core": ">=16.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@angular/common": "^20.0.0",
-    "@angular/compiler": "^20.0.0",
-    "@angular/core": "^20.0.0"
+    "@angular/common": ">=16.0.0",
+    "@angular/compiler": ">=16.0.0",
+    "@angular/core": ">=16.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- relax Angular peer dependencies to `>=16.0.0`
- clarify Angular 16+ compatibility in README
- update lockfile

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686e1ce6af5c8328a422bcbf907a153e