### PR TITLE
Add angular-node example

### DIFF
--- a/examples/angular-node/README.md
+++ b/examples/angular-node/README.md
@@ -1,0 +1,19 @@
+# Angular + Node Example
+
+This example demonstrates how to build a simple Angular application that communicates with a Node.js backend using **ai-sdk-ng**.
+
+The Node server exposes an API endpoint that the Angular app can call for chat or completion features. The frontend uses the `Chat` and `Completion` classes from this library to manage state and interact with the backend.
+
+## Setup
+
+1. Install dependencies for the example:
+   ```bash
+   npm install
+   ```
+2. Start the Node server:
+   ```bash
+   node server.js
+   ```
+3. Serve the Angular application (for example using `ng serve`).
+
+Both projects are kept minimal to focus on demonstrating integration with **ai-sdk-ng**.

--- a/examples/angular-node/chat.service.ts
+++ b/examples/angular-node/chat.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { Chat } from 'ai-sdk-ng';
+
+@Injectable({ providedIn: 'root' })
+export class ChatService {
+  chat = new Chat({ api: '/api/completion' });
+}

--- a/examples/angular-node/package.json
+++ b/examples/angular-node/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "angular-node-example",
+  "private": true,
+  "dependencies": {
+    "express": "^4.18.2",
+    "ai": "^5.0.0-beta.11",
+    "@ai-sdk/openai": "^5.0.0-beta.11",
+    "ai-sdk-ng": "file:../.."
+  }
+}

--- a/examples/angular-node/server.js
+++ b/examples/angular-node/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const { generateText } = require('ai');
+const { openai } = require('@ai-sdk/openai');
+
+const app = express();
+app.use(express.json());
+
+app.post('/api/completion', async (req, res) => {
+  const prompt = req.body.prompt ?? '';
+  try {
+    const { text } = await generateText({
+      model: openai('gpt-3.5-turbo'),
+      prompt,
+    });
+    res.json({ completion: text });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add `examples/angular-node` sample with a small Node.js server
- include minimal Angular service demonstrating usage

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_686e36b2056883288d26629d9bf5e229